### PR TITLE
useReactNative options are optional

### DIFF
--- a/src/reactotron-react-native.ts
+++ b/src/reactotron-react-native.ts
@@ -60,7 +60,7 @@ export interface UseReactNativeOptions {
 
 export interface ReactotronReactNative {
   useReactNative: (
-    options: UseReactNativeOptions
+    options?: UseReactNativeOptions
   ) => Reactotron<ReactotronReactNative> & ReactotronReactNative
   overlay: (App: React.ReactNode) => void
   storybookSwitcher: (App: React.ReactNode) => void


### PR DESCRIPTION
The [example here](https://github.com/infinitered/reactotron/blob/master/docs/quick-start-react-native.md) shows `useReactNative()` as not requiring any options, so this pull request makes the types match that when using `reactotron-react-native` from Typescirpt.