### PR TITLE
[fix] AsyncStorage in React Native is deprecated, use @react-native-c…

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/plugin-transform-react-jsx": "7.3.0",
     "@babel/preset-env": "7.5.4",
     "@babel/preset-typescript": "7.3.3",
+    "@react-native-community/async-storage": "^1.3.3",
     "@semantic-release/git": "7.1.0-beta.3",
     "@types/jest": "24.0.15",
     "@types/node": "11.13.17",

--- a/src/reactotron-react-native.ts
+++ b/src/reactotron-react-native.ts
@@ -1,4 +1,5 @@
-import { Platform, AsyncStorage, NativeModules } from "react-native"
+import { Platform, NativeModules } from "react-native"
+import AsyncStorage from "@react-native-community/async-storage"
 import { createClient, Reactotron } from "reactotron-core-client"
 import getHost from "rn-host-detect"
 


### PR DESCRIPTION
AsyncStorage in React Native is deprecated, use @react-native-community/async-storage instead