### PR TITLE
fix: Fix storybookSwitcher HOC type

### DIFF
--- a/src/reactotron-react-native.ts
+++ b/src/reactotron-react-native.ts
@@ -63,7 +63,7 @@ export interface ReactotronReactNative {
     options: UseReactNativeOptions
   ) => Reactotron<ReactotronReactNative> & ReactotronReactNative
   overlay: (App: React.ReactNode) => void
-  storybookSwitcher: (App: React.ReactNode) => void
+  storybookSwitcher: (App: React.ReactNode) => (Root: React.ReactNode) => React.ReactNode
 }
 
 const reactotron: Reactotron<ReactotronReactNative> & ReactotronReactNative = createClient(DEFAULTS)


### PR DESCRIPTION
Function returned missing in type

fix: https://github.com/infinitered/reactotron/issues/879