### PR TITLE
Remove react peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "semantic-release": "semantic-release"
   },
   "peerDependencies": {
-    "react": "^15.2.1 || 16.0.0-alpha.6 || 16.0.0-alpha.12 || 16.0.0-beta.5 || ^16.0.0",
     "react-native": ">=0.40.0"
   },
   "dependencies": {


### PR DESCRIPTION
Having a peer dependency on React was causing issues with Ignite. I think the more important peer dependency is React Native itself.